### PR TITLE
[FEAT] Async Map-Reduce

### DIFF
--- a/src/query/map-reduce/map-func.ts
+++ b/src/query/map-reduce/map-func.ts
@@ -1,1 +1,3 @@
-export type MapFunc<In, Out> = (TIn) => Out;
+export type MapFunc<Input, Result> =
+  (item: Input, idx: number, array: Input[]) =>
+    Result | Promise<Result>;

--- a/src/query/map-reduce/mapper.ts
+++ b/src/query/map-reduce/mapper.ts
@@ -38,7 +38,7 @@ export class Mapper<QueryResult, Result> implements Queryable<ListResult<Result>
 
     const parentResult = await this.query.result(noCache);
     return this._cachedResult = new ListResultBuilder<Result>()
-      .items(parentResult.items.map(this._callback))
+      .items(await Promise.all(parentResult.items.map(this._callback)))
       .total(parentResult.total)
       .offset(parentResult.offset)
       .limit(parentResult.limit)

--- a/src/query/map-reduce/reduce-func.ts
+++ b/src/query/map-reduce/reduce-func.ts
@@ -1,1 +1,3 @@
-export type ReducerFunc<Input, Result> = (Result, Input) => Result;
+export type ReducerFunc<Input, Result> =
+  (result: Result, item: Input, idx: number, array: Input[]) =>
+    Result | Promise<Result>;

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -118,8 +118,8 @@ export class Query<DbItem> extends BaseQuery<ListResult<DbItem>> implements Quer
    * @param {Result} initialValue
    * @returns {Reducer<DbItem, void, Result>}
    */
-  public reduce<Result>(callback: ReducerFunc<DbItem, Result>, initialValue?: Result): Reducer<DbItem, void, Result> {
-    return new Reducer<DbItem, void, Result>(this, null, callback, initialValue);
+  public reduce<Result>(callback: ReducerFunc<DbItem, Result>, initialValue?: Result): Reducer<DbItem, DbItem, Result> {
+    return new Reducer<DbItem, DbItem, Result>(this, null, callback, initialValue);
   }
 
   /**


### PR DESCRIPTION
- use equal arg-lists for `MapFunc` and `ReduceFunc` as in standard JavaScript
- use async callbacks