### PR TITLE
Fix/2.4.2

### DIFF
--- a/src/command/idb-command/idb-base-write-command.ts
+++ b/src/command/idb-command/idb-base-write-command.ts
@@ -4,6 +4,7 @@ import { IdbContext } from '../../context/idb-context/idb-context';
 import { CreatedEvent } from '../../event/created-event';
 import { UpdatedEvent } from '../../event/updated-event';
 import { Parent } from '../../model/parent';
+import { RefsWriteUtility } from '../../utility/refs-write';
 import { IdbBaseCommand } from './idb-base-command';
 
 export abstract class IdbBaseWriteCommand<T extends NdbDocument> extends IdbBaseCommand<T | T[]> {
@@ -16,8 +17,8 @@ export abstract class IdbBaseWriteCommand<T extends NdbDocument> extends IdbBase
    * @inheritDoc
    *
    * @param {T|T[]} data
-   * @param {boolean} isPartialUpdate
    * @param {Parent|Parent[]} parent
+   * @param {boolean} isPartialUpdate
    * @returns {Promise<boolean>}
    */
   public async write(data: T | T[], parent?: Parent | Parent[], isPartialUpdate?: boolean): Promise<boolean> {
@@ -38,6 +39,10 @@ export abstract class IdbBaseWriteCommand<T extends NdbDocument> extends IdbBase
         const config = this.schema.getConfig(type);
         const objectStore = transaction.objectStore(type);
         await Promise.all(normalizedData[type].map(async item => {
+          if (parent) {
+            RefsWriteUtility.add(item, parent);
+          }
+
           let key = this.getKey(item, config, true);
           if (isNull(key)) {
             await objectStore.put(item);

--- a/src/context/idb-context/idb-context.ts
+++ b/src/context/idb-context/idb-context.ts
@@ -33,9 +33,9 @@ export class IdbContext<Types extends DataStoreTypes> extends Context<Types> {
   public async open(): Promise<void> {
     if (!this.isReady()) {
       this._db = await DBFactory.open(
-          this.dbConfig.name,
-          this.dbConfig.version,
-          this.dbConfig.upgrade || this.onUpgradeNeeded
+        this.dbConfig.name,
+        this.dbConfig.version,
+        this.dbConfig.upgrade || this.onUpgradeNeeded
       );
     }
   }
@@ -86,9 +86,11 @@ export class IdbContext<Types extends DataStoreTypes> extends Context<Types> {
 
   private onUpgradeNeeded(upgradeDb: UpgradeDB) {
     this._logger.onUpgradeNeeded(upgradeDb);
-    this._schema.getTypes().forEach(type => {
-      const config = this._schema.getConfig(type);
-      upgradeDb.createObjectStore(type, { keyPath: config.key });
-    });
+    this._schema.getTypes()
+      .filter(type => !upgradeDb.objectStoreNames.contains(type))
+      .forEach(type => {
+        const config = this._schema.getConfig(type);
+        upgradeDb.createObjectStore(type, { keyPath: config.key });
+      });
   }
 }

--- a/src/logging/idb-logging/idb-logger.ts
+++ b/src/logging/idb-logging/idb-logger.ts
@@ -29,11 +29,13 @@ export class IdbLogger<Types extends DataStoreTypes> extends Logger<Types, IdbCo
   }
 
   public onUpgradeNeeded(upgradeDb: UpgradeDB): void {
-    const logStore = upgradeDb.createObjectStore(IdbLogger.OBJECT_STORE, { keyPath: 'id', autoIncrement: true });
-    logStore.createIndex(IdbLogger.IDX_TIME, 'time');
-    logStore.createIndex(IdbLogger.IDX_ACTION, 'action');
-    logStore.createIndex(IdbLogger.IDX_TYPE, 'type');
-    logStore.createIndex(IdbLogger.IDX_KEY, 'key');
+    if (!upgradeDb.objectStoreNames.contains(IdbLogger.OBJECT_STORE)) {
+      const logStore = upgradeDb.createObjectStore(IdbLogger.OBJECT_STORE, { keyPath: 'id', autoIncrement: true });
+      logStore.createIndex(IdbLogger.IDX_TIME, 'time');
+      logStore.createIndex(IdbLogger.IDX_ACTION, 'action');
+      logStore.createIndex(IdbLogger.IDX_TYPE, 'type');
+      logStore.createIndex(IdbLogger.IDX_KEY, 'key');
+    }
   }
 
   public queryRunner(config: LogQueryConfig): LogQueryRunner<Types> {

--- a/src/query/model/sorter.ts
+++ b/src/query/model/sorter.ts
@@ -82,9 +82,13 @@ export class Sorter<Item extends NdbDocument> {
         break;
 
       case 'boolean':
-        const b1 = value1 ? 2 : 0;
-        const b2 = value2 ? 1 : 0;
-        result = b1 - b2;
+        if (value1 === value2) {
+          result = 0;
+        } else {
+          const b1 = value1 ? 2 : 0;
+          const b2 = value2 ? 1 : 0;
+          result = b1 - b2;
+        }
         break;
 
       case 'object':

--- a/src/utility/index.ts
+++ b/src/utility/index.ts
@@ -1,5 +1,7 @@
+import { RefsWriteUtility } from './refs-write';
 import { isValidKey } from './valid-key';
 
 export {
+  RefsWriteUtility,
   isValidKey
 };

--- a/src/utility/refs-write.ts
+++ b/src/utility/refs-write.ts
@@ -1,0 +1,26 @@
+import { NdbDocument, ReverseReferences, ValidKey } from '@normalized-db/core';
+import { Parent } from '../model/parent';
+
+export class RefsWriteUtility {
+
+  public static add(item: NdbDocument, parent: Parent | Parent[]): void {
+    const refs: ReverseReferences = item._refs || {};
+    if (Array.isArray(parent)) {
+      parent.forEach(p => this.addKey(refs, p.type, p.key));
+    } else {
+      this.addKey(refs, parent.type, parent.key);
+    }
+
+    if (!item._refs) {
+      Object.assign(item, { _refs: refs });
+    }
+  }
+
+  private static addKey(refs: ReverseReferences, type: string, key: ValidKey): void {
+    if (type in refs) {
+      refs[type].add(key);
+    } else {
+      refs[type] = new Set<ValidKey>([key]);
+    }
+  }
+}


### PR DESCRIPTION
- update `_refs` when adding documents to a parent
- `bool`-compare
- add checks for existing object stores during upgrade of `IndexedDB`-instance