### PR TITLE
2.5.0 beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `JavaScript` data stores for `IndexedDB`-wrapper using normalized data (implemented with `TypeScript`).
 
  - **Author**: Sandro Schmid ([saseb.schmid@gmail.com](<mailto:saseb.schmid@gmail.com>))
- - **Version**: 2.5.0-beta.2
+ - **Version**: 2.5.0-beta.3
 
 ## Versioning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,38 +5,24 @@
   "requires": true,
   "dependencies": {
     "@normalized-db/core": {
-      "version": "2.5.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@normalized-db/core/-/core-2.5.0-beta.2.tgz",
-      "integrity": "sha512-ozBQw/6vF/H0oWOT3rtUftMD5HtxcG3x8L5jKdo/nxVSzteZuqwEw6syzLGv+m24a74F1SgGFRrldhp0Bf+4rQ=="
+      "version": "2.5.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@normalized-db/core/-/core-2.5.0-beta.3.tgz",
+      "integrity": "sha512-qYPKscWRetKhOAZMjeoX4jK1E9+yUra7aVwE7crDyN0l1QtjkUwy/kRMrTIKWHJmEKHJtQT0ePDqDeXnfH8MNg=="
     },
     "@normalized-db/denormalizer": {
-      "version": "2.5.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@normalized-db/denormalizer/-/denormalizer-2.5.0-beta.1.tgz",
-      "integrity": "sha512-pKex/70LfhWdBK6jps8H+98X+2FMpYQHkirnaiRi6oe6jqpbEMZi9uz5VAyOdfrGykY/CJ0mgCNiVlCrkFxhGw==",
+      "version": "2.5.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@normalized-db/denormalizer/-/denormalizer-2.5.0-beta.3.tgz",
+      "integrity": "sha512-Ur3a/BOg2RkPV/e2/jBgp6t6I5N/ZogJ4k7vPBnFKyYBjlcKjv5Uq4YZGPgH2cjiRkmp1M0UcMmddmq2qetMVw==",
       "requires": {
-        "@normalized-db/core": "2.5.0-beta.1"
-      },
-      "dependencies": {
-        "@normalized-db/core": {
-          "version": "2.5.0-beta.1",
-          "resolved": "https://registry.npmjs.org/@normalized-db/core/-/core-2.5.0-beta.1.tgz",
-          "integrity": "sha512-AaiWsxEr0Ej9PaQhbPL147bzTP1rbeP6VyccVw1y6rKhwXdF488B7p62nZOonjFvkjVeUCxBjIUB0mr+/mL6yQ=="
-        }
+        "@normalized-db/core": "2.5.0-beta.3"
       }
     },
     "@normalized-db/normalizer": {
-      "version": "2.5.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@normalized-db/normalizer/-/normalizer-2.5.0-beta.1.tgz",
-      "integrity": "sha512-svpFUqnuT5FKBPMem0w40zJ0RbhTP7MeokAbPUg3iuAufvAGc2HlI62XQeKx/oN0FYGQkLDWAgWBZIvpctgcUg==",
+      "version": "2.5.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@normalized-db/normalizer/-/normalizer-2.5.0-beta.3.tgz",
+      "integrity": "sha512-oXcmvIUD4w/3u6hTwmab5Fxcs8RJ8SqLJfNy5Y0E1Eve7No5iusYeM3PO6P6nsmc2f9u2BT/MDMrl7f1JvOt7A==",
       "requires": {
-        "@normalized-db/core": "2.5.0-beta.1"
-      },
-      "dependencies": {
-        "@normalized-db/core": {
-          "version": "2.5.0-beta.1",
-          "resolved": "https://registry.npmjs.org/@normalized-db/core/-/core-2.5.0-beta.1.tgz",
-          "integrity": "sha512-AaiWsxEr0Ej9PaQhbPL147bzTP1rbeP6VyccVw1y6rKhwXdF488B7p62nZOonjFvkjVeUCxBjIUB0mr+/mL6yQ=="
-        }
+        "@normalized-db/core": "2.5.0-beta.3"
       }
     },
     "@types/chai": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@normalized-db/data-store",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@normalized-db/data-store",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "author": "Sandro Schmid <saseb.schmid@gmail.com>",
   "license": "MIT",
   "description": "`JavaScript` data stores for `IndexedDB` using normalized data (implemented with `TypeScript`).",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "build-and-publish": "npm run clean-build && npm publish"
   },
   "dependencies": {
-    "@normalized-db/core": "2.5.0-beta.2",
-    "@normalized-db/denormalizer": "2.5.0-beta.1",
-    "@normalized-db/normalizer": "2.5.0-beta.1",
+    "@normalized-db/core": "2.5.0-beta.3",
+    "@normalized-db/denormalizer": "2.5.0-beta.3",
+    "@normalized-db/normalizer": "2.5.0-beta.3",
     "idb": "2.0.3"
   },
   "devDependencies": {

--- a/src/command/idb-command/idb-clear-command.ts
+++ b/src/command/idb-command/idb-clear-command.ts
@@ -44,6 +44,7 @@ export class IdbClearCommand extends IdbBaseCommand<IdbContext<any>> implements 
 
     try {
       involvedTypes.forEach(osn => transaction.objectStore(osn).clear());
+      await transaction.complete;
     } catch (e) {
       try {
         transaction.abort();
@@ -54,7 +55,9 @@ export class IdbClearCommand extends IdbBaseCommand<IdbContext<any>> implements 
       return false;
     }
 
-    this._eventQueue.enqueue(new ClearedEvent(involvedTypes.join(';')));
+    involvedTypes.forEach(involvedType =>
+        this._eventQueue.enqueue(new ClearedEvent(involvedType)));
+
     this.onSuccess();
     return true;
   }

--- a/src/context/context.builder.ts
+++ b/src/context/context.builder.ts
@@ -1,4 +1,4 @@
-import { ISchema, ISchemaConfig, Schema } from '@normalized-db/core';
+import { ISchema, ISchemaConfig, isNull, Schema } from '@normalized-db/core';
 import { IDenormalizerBuilder } from '@normalized-db/denormalizer';
 import { INormalizerBuilder } from '@normalized-db/normalizer';
 import { LogConfig } from '../logging/config/log-config';
@@ -33,7 +33,7 @@ export abstract class ContextBuilder<Types extends DataStoreTypes, Ctx extends C
   }
 
   public enableLogging(value?: boolean | LogConfig<Types>): this {
-    this._enableLogging = value;
+    this._enableLogging = isNull(value) ? true : value;
     return this;
   }
 

--- a/src/logging/config/log-config.ts
+++ b/src/logging/config/log-config.ts
@@ -75,7 +75,7 @@ export class LogConfig<Types extends DataStoreTypes> implements ILogConfig {
           : logConfig.eventSelection === eventType;
     }
 
-    if (isEnabled && key && logConfig.keys && logConfig.keys.length > 0) {
+    if (isEnabled && !isNull(key) && logConfig.keys && logConfig.keys.length > 0) {
       isEnabled = logConfig.keys.indexOf(key) >= 0;
     }
 

--- a/src/logging/config/log-config.ts
+++ b/src/logging/config/log-config.ts
@@ -1,4 +1,12 @@
-import { EventType, ILogConfig, IStoreLogConfig, LogMode, StoreLogBuilder, ValidKey } from '@normalized-db/core';
+import {
+  EventType,
+  ILogConfig,
+  isNull,
+  IStoreLogConfig,
+  LogMode,
+  StoreLogBuilder,
+  ValidKey
+} from '@normalized-db/core';
 import { DataStoreTypes } from '../../model/data-store-types';
 
 export class LogConfig<Types extends DataStoreTypes> implements ILogConfig {
@@ -9,6 +17,21 @@ export class LogConfig<Types extends DataStoreTypes> implements ILogConfig {
   public constructor(types: Map<Types, IStoreLogConfig>, defaultConfig?: IStoreLogConfig) {
     this._types = types;
     this._defaultConfig = defaultConfig || new StoreLogBuilder().build();
+
+    this._types.forEach(config => {
+      if (isNull(config.mode)) {
+        config.mode = this._defaultConfig.mode;
+      }
+
+      if ((!config.eventSelection || (Array.isArray(config.eventSelection) && config.eventSelection.length === 0)) &&
+          this._defaultConfig.eventSelection) {
+        config.eventSelection = this._defaultConfig.eventSelection;
+      }
+
+      if ((!config.keys || config.keys.length === 0) && this._defaultConfig.keys) {
+        config.keys = this._defaultConfig.keys;
+      }
+    });
   }
 
   public hasType(type: Types): boolean {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -58,8 +58,9 @@ export abstract class Logger<Types extends DataStoreTypes, Ctx extends Context<T
   public abstract clear(options?: ClearLogsOptions<Types>): Promise<boolean>;
 
   protected isLoggingEnabled(type: Types, event: BaseEvent<Types, any>): boolean {
-    return (this._config && this._config.isLoggingEnabled(type, event.eventType, event.itemKey)) ||
-        this._schemaLogConfig.isLoggingEnabled(type, event.eventType, event.itemKey);
+    return this._config
+        ? this._config.isLoggingEnabled(type, event.eventType, event.itemKey)
+        : this._schemaLogConfig.isLoggingEnabled(type, event.eventType, event.itemKey);
   }
 
   protected getLogMode(type: Types): LogMode {


### PR DESCRIPTION
* `LogConfig`: Set defaults to all types
* Use `isNull` for checking availability of `key`-arg
* Enable logging if builder-function is called without an argument
* Completely override schema-log-config when using a programmatic log-config
* `ClearCommand`: Wait for transaction to complete, do not join all `ClearedEvents` to only one
* Update dependencies